### PR TITLE
Add initial Minikube config and instructions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,10 @@
-version: "3.2"
+# A Docker Compose configuration file
+# Useful for testing container orchestation
 
+version: "3.2"
 services:
 
+  # Nixster server
   nixster:
     image: stencila/nixster
     build: .
@@ -23,6 +26,7 @@ services:
         target: /nix
         read_only: true
 
+  # Docker-in-Docker (dind) to build Docker images
   docker-in-docker:
     image: docker:dind
     # The `dind` image always needs to be run privileged

--- a/minikube-build.yml
+++ b/minikube-build.yml
@@ -15,6 +15,15 @@ spec:
       # which makes the `nixster` CLI tool complain about unrecognised options
       # because of the `NIXTER_` prefix clash.
       enableServiceLinks: false
+      initContainers:
+        # Create the `profiles` directory
+        # This is a workaround which could be avoided by a fix in the `nixster` app
+        - name: init-nix-volumne
+          image: busybox
+          command: ["sh", "-c", "mkdir -p /nixroot/nix/profiles/"]
+          volumeMounts:
+            - name: nix-volume
+              mountPath: /nixroot
       containers:
         # Build container with write access to the `/nixroot` directory
         - name: build-container
@@ -22,16 +31,17 @@ spec:
           # Don't pull image, instead use the one built locally
           imagePullPolicy: Never
           # Build the environment into the `/nixroot` directory
+          # To keep thing fast and small only build a small image
           command: ["nixster"]
-          args: ["build", "multi-mega", "--store", "/nixroot"]
+          args: ["build", "r", "--store", "/nixroot"]
           volumeMounts:
             - name: nix-volume
               mountPath: /nixroot
           # Build needs to be priviledged
           securityContext:
             privileged: true
-      # We're using an empty directory here just for testing
-      # In production this is likely to be a Persistent Volume Claim (PVC)
+      # Use the ReadWriteOnce PVC
       volumes:
         - name: nix-volume
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: nixster-pvc-rwo

--- a/minikube-build.yml
+++ b/minikube-build.yml
@@ -1,0 +1,37 @@
+# An example Kubernetes deployment for building Nixster environments
+# Designed for testing using Minikube but should
+# require little modification for use in a production cluster.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nixster-build-job
+spec:
+  backoffLimit: 4
+  template:
+    spec:
+      restartPolicy: Never
+      # Prevent Kubernetes setting `NIXSTER_SERVICE_*` environment variables
+      # which makes the `nixster` CLI tool complain about unrecognised options
+      # because of the `NIXTER_` prefix clash.
+      enableServiceLinks: false
+      containers:
+        # Build container with write access to the `/nixroot` directory
+        - name: build-container
+          image: stencila/nixster
+          # Don't pull image, instead use the one built locally
+          imagePullPolicy: Never
+          # Build the environment into the `/nixroot` directory
+          command: ["nixster"]
+          args: ["build", "multi-mega", "--store", "/nixroot"]
+          volumeMounts:
+            - name: nix-volume
+              mountPath: /nixroot
+          # Build needs to be priviledged
+          securityContext:
+            privileged: true
+      # We're using an empty directory here just for testing
+      # In production this is likely to be a Persistent Volume Claim (PVC)
+      volumes:
+        - name: nix-volume
+          emptyDir: {}

--- a/minikube-serve.yml
+++ b/minikube-serve.yml
@@ -1,0 +1,80 @@
+# An example Kubernetes deployment for serving Nixster
+# Designed for testing using Minikube but should
+# require little modification for use in a production cluster.
+
+# Server deployment for serving sessions
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nixster-serve-deployment
+spec:
+  template:
+    metadata:
+      labels:
+        app: nixster-app
+    spec:
+      containers:
+
+        # Nixster server
+        - name: server-container
+          image: stencila/nixster
+          # Don't pull image, instead use the one built locally
+          imagePullPolicy: Never
+          # Server needs to listen on 0.0.0.0 to accept connections
+          # from outside of the container
+          command: ["nixster"]
+          args: ["serve", "--address", "0.0.0.0"]
+          # Tell the Docker client how to connect to the Docker daemon
+          # in the sibling container
+          env:
+            - name: DOCKER_HOST
+              value: tcp://127.0.0.1:2375
+          ports:
+            - containerPort: 3000
+          # Server needs read access to `/nix` to resolve the location for an
+          # environment (i.e. resolve the symlink from a `/nix/profiles` to `/nix/store/*-user-environment`)
+          # so that `PATH` etc can be set properly.
+          volumeMounts:
+            - name: nix-volume
+              mountPath: /nix
+              readOnly: true
+
+        # Docker-in-Docker (dind) to build Docker images
+        - name: docker-container
+          image: docker:dind
+          securityContext:
+            privileged: true
+          ports:
+            - containerPort: 2375
+          # Docker daemon needs read access to `/nix` so that it can mount 
+          # `/nix/store` into the user session containers
+          volumeMounts:
+            - name: nix-volume
+              mountPath: /nix
+              readOnly: true
+
+      # When using Minikube you can mount a local `./nixroot` into the cluster using
+      #    minikube mount $PWD/nixroot:/nixroot
+      # In production this is likely to be a Persistent Volume Claim (PVC)
+      volumes:
+        - name: nix-volume
+          hostPath:
+            path: /nixroot/nix
+
+---
+
+# Expose the server as a `Service` for testing
+# outside of Minikube
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: nixster-service
+spec:
+  type: NodePort
+  selector:
+    app: nixster-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 3000

--- a/minikube-serve.yml
+++ b/minikube-serve.yml
@@ -36,6 +36,7 @@ spec:
           # so that `PATH` etc can be set properly.
           volumeMounts:
             - name: nix-volume
+              subPath: nix
               mountPath: /nix
               readOnly: true
 
@@ -50,16 +51,17 @@ spec:
           # `/nix/store` into the user session containers
           volumeMounts:
             - name: nix-volume
+              subPath: nix
               mountPath: /nix
               readOnly: true
 
-      # When using Minikube you can mount a local `./nixroot` into the cluster using
-      #    minikube mount $PWD/nixroot:/nixroot
-      # In production this is likely to be a Persistent Volume Claim (PVC)
+      # Use the ReadWriteMany PVC (even though we are only mounting
+      # as read only this seeems to be necessary it does not work 
+      # with `nixster-pvc-rom`)
       volumes:
         - name: nix-volume
-          hostPath:
-            path: /nixroot/nix
+          persistentVolumeClaim:
+            claimName: nixster-pvc-rwm
 
 ---
 

--- a/minikube-volumes.yml
+++ b/minikube-volumes.yml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: nixster-pv
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: 1Gi
+  # Minikube will persist files stored under /data so we use that to simulate
+  # a persistent disk in production
+  # See https://github.com/kubernetes/minikube/blob/master/docs/persistent_volumes.md
+  hostPath:
+    path: /data/nixroot
+
+
+# The following PVCs have different accessModes for testing what was needed
+# for build and serve phases. In production, only one should be needed?
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nixster-pvc-rwm
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nixster-pvc-rwo
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nixster-pvc-rom
+spec:
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: 1Gi

--- a/src/nix.ts
+++ b/src/nix.ts
@@ -36,7 +36,6 @@ try {
 // Currently we're putting generate Nix profiles in the /nix directory.
 // This is somewhat arbitrary.
 const profiles = path.join('/', 'nix', 'profiles')
-mkdirp.sync(profiles)
 
 /**
  * Add a channel
@@ -249,7 +248,7 @@ export async function search (term: string, type: string = '', limit: number = 1
  */
 export function location (env: string): string {
   const profile = path.join(profiles, env)
-  if (!fs.existsSync(profile)) throw new Error(`Profile for environment "${env}" not exist at "${profile}"`)
+  if (!fs.existsSync(profile)) throw new Error(`Profile for environment "${env}" does not exist at "${profile}"`)
   const location = fs.realpathSync(profile)
   if (location.length === 0) throw new Error(`Could not resolve location of environment "${env}" from the profile "${profile}"`)
   return location
@@ -296,6 +295,8 @@ export async function install (env: string, pkgs: Array<string>, clean: boolean 
     } else {
       profile = path.join(profiles, env)
     }
+    // Ensure the profiles directory is present
+    mkdirp.sync(path.dirname(profile))
     args = args.concat(
       '--profile', profile,
       '--attr', channels[channel].map((pkg: any) => pkg.attr)

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -94,7 +94,8 @@ expressWs.app.ws('/shell', async (ws: any, req: express.Request) => {
       }
     })
 
-    let env = new Environment('multi-mega')
+    // For now, use an arbitrary, small environment for testing purposes.
+    let env = new Environment('r')
 
     const sessionParameters = new SessionParameters()
     sessionParameters.platform = Platform.DOCKER


### PR DESCRIPTION
This takes the next step towards deployment by creating Minikube config files (starting from the `docker-compose.yml` config). See docs in config.

@beneboy: making a PR mainly for your info. Maybe give the instructions a go and merge this if it works as advertised.