### PR TITLE
feat(serve): Added JWT authentication functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1338,6 +1338,11 @@
         "node-int64": "^0.4.0"
       }
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -2002,6 +2007,14 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
+      "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -2227,6 +2240,29 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.1.4.tgz",
       "integrity": "sha512-HdmbVF4V4w1q/iz++RV7bUxIeepTukWewiJGkoCKQMtvPF11MLTa7It9PRc/reysXXZSEyD4Pthchju+IUbMiQ=="
+    },
+    "express-jwt": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/express-jwt/-/express-jwt-5.3.1.tgz",
+      "integrity": "sha512-1C9RNq0wMp/JvsH/qZMlg3SIPvKu14YkZ4YYv7gJQ1Vq+Dv8LH9tLKenS5vMNth45gTlEUGx+ycp9IHIlaHP/g==",
+      "requires": {
+        "async": "^1.5.0",
+        "express-unless": "^0.3.0",
+        "jsonwebtoken": "^8.1.0",
+        "lodash.set": "^4.0.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+        }
+      }
+    },
+    "express-unless": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/express-unless/-/express-unless-0.3.1.tgz",
+      "integrity": "sha1-JVfBRudb65A+LSR/m1ugFFJpbiA="
     },
     "express-ws": {
       "version": "4.0.0",
@@ -2847,14 +2883,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2869,20 +2903,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2999,8 +3030,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3012,7 +3042,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3027,7 +3056,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3035,14 +3063,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3061,7 +3087,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3142,8 +3167,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3155,7 +3179,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3241,8 +3264,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3278,7 +3300,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3341,14 +3362,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -5010,6 +5029,29 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.4.0.tgz",
+      "integrity": "sha512-coyXjRTCy0pw5WYBpMvWOMN+Kjaik2MwTUIq9cna/W7NpO9E+iYbumZONAz3hcr+tXFJECoQVrtmIoC3Oz0gvg==",
+      "requires": {
+        "jws": "^3.1.5",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -5020,6 +5062,25 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jwa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.2.0.tgz",
+      "integrity": "sha512-Grku9ZST5NNQ3hqNUodSkDfEBqAmGA1R8yiyPHOnLzEKI0GaCQC/XhFmsheXYuXzFQJdILbh+lYBiliqG5R/Vg==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.10",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.1.tgz",
+      "integrity": "sha512-bGA2omSrFUkd72dhh05bIAN832znP4wOU3lfuXtRBuGTbsmNmDXMQg28f0Vsxaxgk4myF5YkKQpz6qeRpMgX9g==",
+      "requires": {
+        "jwa": "^1.2.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "kind-of": {
@@ -5205,6 +5266,11 @@
         "lodash._bindcallback": "^3.0.0"
       }
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -5217,6 +5283,31 @@
       "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
       "dev": true
     },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
@@ -5227,6 +5318,16 @@
         "lodash.isarguments": "^3.0.0",
         "lodash.isarray": "^3.0.0"
       }
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "ellipsize": "^0.1.0",
     "express": "^4.16.4",
     "express-async-handler": "^1.1.4",
+    "express-jwt": "^5.3.1",
     "express-ws": "^4.0.0",
     "fs-extra": "^7.0.1",
     "glob": "^7.1.3",

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -3,6 +3,8 @@ import stream from 'stream'
 
 import express from 'express'
 
+const jwt = require('express-jwt')
+
 import Environment, { Platform, SessionParameters } from './Environment'
 
 const app = express()
@@ -16,6 +18,17 @@ const jsonParser = require('body-parser').json()
 app.use(jsonParser)
 
 const DEFAULT_ENVIRONMENT = 'multi-mega'
+
+/**
+ * Secret for JSON web tokens.
+ */
+let JWT_SECRET = process.env.JWT_SECRET
+if (!JWT_SECRET) {
+  if (process.env.NODE_ENV === 'development') JWT_SECRET = 'not-a-secret'
+  else throw Error('JWT_SECRET must be set')
+}
+
+app.use(jwt({ secret: JWT_SECRET }))
 
 /**
  * Validates that all the `requiredParameters` are properties of `body`.
@@ -75,10 +88,44 @@ function doRequestValidation (request: express.Request, response: express.Respon
   return true
 }
 
-// todo: rename shell to interact
+/**
+ * Get the JWT data from a Request. Will either return the JWT data or null:
+ *
+ * The `exepectedContainerId` argument is the containerId that is expected to be found in the JWT. If one is provieded
+ * and it does not exist/does not match in the JWT token then a 403 status and message will be sent to the response.
+ * Similarly, if this is null and a containerId is sent a 403 status is sent and message written.
+ *
+ * @param request
+ * @param response
+ * @param expectedContainerId
+ */
+function getJwtData (request: express.Request, response: express.Response, expectedContainerId: string | null = null): any {
+  // @ts-ignore
+  const jwtData: any = request.user
+
+  if (expectedContainerId) {
+    if (expectedContainerId !== jwtData.cid) {
+      response.status(403).send('Contained ID in JWT does not match expected.')
+      return null
+    }
+  } else if (jwtData.cid) {
+    response.status(403).send('Attempted to use JWT that already has a container id.')
+    return null
+  }
+
+  return jwtData
+}
+
 // Instantiate shell and set up data handlers
 expressWs.app.ws('/shell', async (ws: any, req: express.Request) => {
   const environment = req.query.environment || DEFAULT_ENVIRONMENT
+
+  const jwtData = getJwtData(req, ws, null)
+
+  if (jwtData === null) {
+    return ws.close()
+  }
+
   try {
     // Create streams that pipe between the Websocket and
     // the pseudo terminal
@@ -113,6 +160,12 @@ expressWs.app.ws('/shell', async (ws: any, req: express.Request) => {
 expressWs.app.ws('/interact', async (ws: any, req: express.Request) => {
   const environment = req.query.environment || DEFAULT_ENVIRONMENT
   const containerId = req.query.containerId || ''
+
+  const jwtData = getJwtData(req, ws, containerId)
+
+  if (jwtData === null) {
+    return ws.close()
+  }
 
   try {
     // Create streams that pipe between the Websocket and
@@ -155,6 +208,12 @@ app.use((error: Error, req: express.Request, res: express.Response, next: any) =
 })
 
 expressWs.app.post('/start', async (req: express.Request, res: express.Response) => {
+  const jwtData = getJwtData(req, res)
+
+  if (jwtData === null) {
+    return res.end()
+  }
+
   if (!doRequestValidation(req, res, ['environmentId'])) {
     return res.end()
   }
@@ -176,6 +235,12 @@ expressWs.app.post('/execute', async (req: express.Request, res: express.Respons
     return res.end()
   }
 
+  const jwtData = getJwtData(req, res, req.body.containerId)
+
+  if (jwtData === null) {
+    return res.end()
+  }
+
   const env = new Environment(req.body.environmentId)
 
   const sessionParameters = new SessionParameters()
@@ -191,6 +256,12 @@ expressWs.app.post('/execute', async (req: express.Request, res: express.Respons
 expressWs.app.post('/stop', async (req: express.Request, res: express.Response) => {
   // req: some JSON -> with container ID that will stop the container
   if (!doRequestValidation(req, res, ['environmentId', 'containerId'])) {
+    return res.end()
+  }
+
+  const jwtData = getJwtData(req, res, req.body.containerId)
+
+  if (jwtData === null) {
     return res.end()
   }
 

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -105,7 +105,7 @@ function getJwtData (request: express.Request, response: express.Response, expec
 
   if (expectedContainerId) {
     if (expectedContainerId !== jwtData.cid) {
-      response.status(403).send('Contained ID in JWT does not match expected.')
+      response.status(403).send('Container ID in JWT does not match expected.')
       return null
     }
   } else if (jwtData.cid) {


### PR DESCRIPTION
I have added JWT to the serve methods.

The JWT can either contain a containerId (`cid`) or not.

My thinking is that some methods (e.g. start) should only be callable by the hub backend and so it will be able to generate those JWTs and use that as authentication to start the container.

Other methods like execute, the hub will be able to generate the JWT with the container ID and then pass that to the browser, which can then directly send to /execute on Nixster, and Nixster will validate the JWT because it was generated with the same token.

If a Nixster method expects a container ID and one was not supplied (or vice versa) then 403 statuses are returned.